### PR TITLE
v1.1.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,26 +254,26 @@ ClinSV works by creating shell scripts which aggregate multiple tools together. 
 
 ```
     "bigwig":{
-            "createWigs": "walltime=6:00:00,ncpus=16,mem=10GB",
-            "q0": "walltime=2:00:00,ncpus=1,mem=60GB,jobfs=100gb",
-            "q20": "walltime=2:00:00,ncpus=1,mem=60GB,jobfs=100gb",
-            "mq" : "walltime=5:00:00,ncpus=1,mem=60GB,jobfs=100gb"
+            "createWigs",
+            "q0",
+            "q20",
+            "mq"
     },
     "lumpy":{
-            "caller": "walltime=22:00:00,mem=60GB,ncpus=1,jobfs=300gb",
-            "depth": "walltime=8:00:00,ncpus=12,mem=30GB,jobfs=50G"
+            "caller",
+            "depth"
     },
     "cnvnator":{
-            "caller": "walltime=6:00:00,mem=30GB,ncpus=16,jobfs=300gb"
+            "caller"
     },
     "annotate":{
-            "main":"walltime=10:00:00,mem=10GB,ncpus=1,jobfs=20gb"
+            "main"
     },
     "prioritize":{
-            "main": "walltime=1:00:00,mem=3GB,ncpus=1,jobfs=20gb"
+            "main"
     },
     "qc":{
-            "main": "walltime=01:00:00,mem=2GB,ncpus=1,jobfs=20gb"
+            "main"
     }
 
 ```

--- a/README.md
+++ b/README.md
@@ -26,10 +26,24 @@ Please refer to the [manuscript](https://doi.org/10.1186/s13073-021-00841-x) for
 
 
 # ClinSV version 1.1.0
-This repository contains the source code and Docker files required to run ClinSV version 1.1.0. This version supports both GRCh38 and GRCh37 decoy (hs37d5) reference genome.
+This repository contains the source code and Docker files required to run ClinSV version 1.1.0. This version supports both GRCh38 and GRCh37 decoy (hs37d5) reference genomes.
+
+The easiest way to run ClinSV is via Docker. If you really want to compile from source, then see [INSTALL_b38.md](INSTALL_b38.md).
+
+## Release Notes - v1.1.0  
+- Able to to use either ref-genomes on the fly depending on the file path passed into the `-ref` command. `-ref /app/ref-data/refdata-b38` for GRCh38 (b38) and `-ref /app/ref-data/refdata-b37` for GRCh38 (b37).
+- Support of hg19 style nomenclature (ex `1,2,3,4..X,Y,MT`) for input bams using the b37 reference genome. Note this is an unstable feature. It is recommended to lift over your bam files first to the ref genome you would want to use.
+-  Able to use maximum available CPUs for the bigwig:createWigs and lumpy:caller steps.
+- Able to limit the amount of CPUs used by ClinSV with the `-j` command where a path to a json file which contains the max limit on resources used for each step is passed as input. For more details see [here](Utils/).
+- Added script to make a smoother development experience using the docker container. For more details see [here](Utils/).
+- Bug fix #61: igv .xml file now uses the correct reference genome dependeant on the reference genome used.
+- Bug fix #60: the coverage by chromosome view in the QC report is now outputed correctly.
+
 
 ## Download
+ClinSV requires a reference genome to run. Currently only GRCh38 and GRCh37 decoy (hs37d5) reference genomes are supported.
 
+### GRCh38 (b38) files
 Download human genome reference data GRCh38 (37GB):
 
 ```
@@ -42,65 +56,99 @@ Download a sample bam to test ClinSV (71GB):
 ```
 wget https://clinsv.s3.ccia.org.au/clinsv_b38/NA12878_b38.bam
 wget https://clinsv.s3.ccia.org.au/clinsv_b38/NA12878_b38.bam.bai
-
 ```
-or here is a smaller BAM file (4.7GB)
+or a smaller subsampled BAM file (4.7GB)
 ```
 wget https://clinsv.s3.ccia.org.au/clinsv_b38/NA12878.grch38.subsampled.bam
 wget https://clinsv.s3.ccia.org.au/clinsv_b38/NA12878.grch38.subsampled.bam.bai
 ```
 
-The easiest way to run ClinSV is via Docker. If you really want to compile from source, then see [INSTALL_b38.md](INSTALL_b38.md).
+### GRCh37 (b37) files
+Download human genome reference data GRCh37 decoy (hs37d5):
+
+```
+wget https://clinsv.s3.ccia.org.au/clinsv_b37/refdata-b37_v0.9.tar
+# check md5sum: 921ecb9b9649563a16e3a47f25954951
+tar xf refdata-b37_v0.9.tar
+```
+
+Download a sample bam to test ClinSV:
+
+```
+wget https://clinsv.s3.ccia.org.au/clinsv_b37/NA12878_v0.9.bam
+wget https://clinsv.s3.ccia.org.au/clinsv_b37/NA12878_v0.9.bam.bai
+```
 
 ## File structure to run Docker image
 
-In order to use the docker image your working directory needs to be set up as below:
+In order to use the docker image with the docker run instructions, your working directory needs to be set up as below:
 ```
 Current working directory
-|   |contains your bam files *.bam
-|   |contains your bai files *.bai
+|    |contains your bam files *.bam
+|    |contains your bai files *.bai
 └───clinsv
-|    |
-|    └───refdata-b38
-|    |     |
-|    |     └───refdata-b38
-|    |     |       | /all of refdata-b38's content/ 
-|    
+|    └───refdata-b3x
+|          | /all of refdata-b3x's content/  
 └───test_run
       | this is where clinsv generates all its output
-
 ```
-**Its important to note that the provided b38 ref data (after extracting) needs to be put within a parent folder of the same name as described above.**
+**Extract the refdata-b3x tar files in the clinsv folder**
 
 ## Run ClinSV
 
 
 ### Using Docker
 ```
-docker pull mrbradley2/clinsv:v1.0
+docker pull containerregistrypubliccb.azurecr.io/clinsv:v1.1.0
 
-refdata_path=$PWD/clinsv/refdata-b38
+refdata_path=$PWD/clinsv/
 input_path=$PWD
 project_folder=$PWD/test_run
 
 docker run -v $refdata_path:/app/ref-data \
 -v $project_folder:/app/project_folder  \
 -v $input_path:/app/input  \
-
---entrypoint "perl" mrbradley2/clinsv:v1.0.1 /app/clinsv/bin/clinsv \
+--entrypoint "perl" containerregistrypubliccb.azurecr.io/clinsv:v1.1.0 /app/clinsv/bin/clinsv \
 -r all \
 -p /app/project_folder/ \
 -i "/app/input/*.bam" \
--ref /app/ref-data/refdata-b38 \
+-ref /app/ref-data/refdata-b3x \
 -w
 ```
-Expect this to ~8 hours for a 30x WGS file.
+Expect this to take ~8 hours for a 30x WGS 80GB BAM file.
+Expect this to take ~2.5 hours with the subsampled 4.7GB BAM file.
 
+### Using Singularity
+Currently only ClinSV v0.9 is supported on Singularity, as such, only the GRCh37 decoy (hs37d5) reference genome and respecitvely aligned BAMs can be used.
+```
+wget https://clinsv.s3.ccia.org.au/clinsv_b37/clinsv.sif
+singularity run clinsv.sif \
+  -i "$input_path/*.bam" \
+  -ref $refdata_path \
+  -p $PWD/project_folder
+```
+### Linux Native
 
-## ClinSV options
+Download precompiled ClinSV bundle for CentOS 6.8 x86_64. Also only uses ClinSV v0.9, as such, only the GRCh37 decoy (hs37d5) reference genome and respecitvely aligned BAMs can be used.
 
 ```
--p Project folder [current_dir]. 
+wget https://clinsv.s3.ccia.org.au/clinsv_b37/ClinSV_x86_64_v0.9.tar.gz
+tar zxf ClinSV_x86_64_v0.9.tar.gz
+clinsv_path=$PWD/clinsv
+export PATH=$clinsv_path/bin:$PATH
+clinsv -r all -p $PWD/project_folder -i "$input_path/*.bam" -ref $refdata_path
+```
+## ClinSV usage and options
+
+```
+### This script runs ClinSV on a single node ###
+Version: v1.1.0
+Author: Andre E Minoche, James Bradley, Mark J Cowley
+
+usage: clinsv -p /path/to/project -i /path/to/input_bams/*.bam -ref /path/to/ref_data [options]
+
+### Options:
+-p Project folder [current_dir]. This can take two colon separated values, see README.md
 -r Analysis steps to run [all]. All is equivalent to bigwig,lumpy,cnvnator,annotate,prioritize,qc,igv
    Multiple steps must be comma separated with no spaces in-between.
 -i Path to input bams [./input/*.bam]. Requires bam index ending to be \"*.bam.bai.\". 
@@ -112,83 +160,26 @@ Expect this to ~8 hours for a 30x WGS file.
 -n Name stem for joint-called files (e.g joint vcf file) in case different sample grouping exists. 
    This is necessary if different sets of samples specified wtih -s are analysed within the same 
    project folder, E.g. a family trio and a set of single proband individuals.
--l Lumpy batch size. Number of sampels to be joint-called [15]. 
--ref Path to reference data dir [./refdata-b37].
-
 -w short for 'web': In the IGV session file, stream the annotation tracks from a server. Convenient if you
-   prefer to run ClinSV on an HPC (where you have a copy of the annotation bundle) and view results on your desktop
--hg19 Specify that input bams use hg19 chromosome nomenclature, use when using input bams that are
-	aligned to hg19 along with the reference data dir refdata-b37.
+    prefer to run ClinSV on an HPC (where you have a copy of the annotation bundle) and view results on your desktop 
+-j Path to json file which specifies the resources to be used for each step
+-l Lumpy batch size. Number of sampels to be joint-called [15]. 
+-ref Path to reference data dir [./refdata-b38 or ./refdata-b37]. This can take two colon separated values, see README.md
+-hg19 Specify that input bams use hg19 chromosome nomenclature (e.g. short form '1,2,3..X,Y,MT'), use when using input bams that are
+      aligned to hg19. Ensure to use with the reference data refdata-b37. Warning this is an unstable feature. Highly recommend to lift over input bams to
+      GRCh37/GRCh38 with another tool, then use ClinSV with those ref genomes.
+
 -eval Create the NA12878 validation report section [no].
 -h print this help
+
+# To rerun a specific analysis steps:
+clinsv -r annotsv,prioritize -f
 ```
 
 ### Advanced options
 When providing a [pedigree file](misc/sampleInfo.ped), the output will contain additional columns showing e.g. how often a variant was observed among affected and unaffected individuals. The pedigree file has to be named "sampleInfo.ped" and it has to be placed into the project folder.
 
 To mark variants affecting user defined candidate genes, a [gene list](misc/testGene.ids) list has to be placed into the project folder and named "testGene.ids". Gene names have to be as in ENSEMBL GRCh37.
-
-# ClinSV version 0.9
-Install and usage instructions for ClinSV v0.9
-## Download
-
-Download human genome reference data GRCh37 decoy (hs37d5):
-
-```
-wget https://clinsv.s3.ccia.org.au/clinsv_b37/refdata-b37_v0.9.tar
-
-# check md5sum: 921ecb9b9649563a16e3a47f25954951
-tar xf refdata-b37_v0.9.tar
-refdata_path=$PWD/clinsv/refdata-b37
-```
-
-Download a sample bam to test ClinSV:
-
-```
-wget https://clinsv.s3.ccia.org.au/clinsv_b37/NA12878_v0.9.bam
-wget https://clinsv.s3.ccia.org.au/clinsv_b37/NA12878_v0.9.bam.bai
-input_path=$PWD
-```
-
-The ClinSV software can be downloaded precompiled, as a Singularity image or through Docker. Please refer to the section below.
-
-
-## Run ClinSV
-
-### Using Singularity
-```
-wget https://clinsv.s3.ccia.org.au/clinsv_b37/clinsv.sif
-singularity run clinsv.sif \
-  -i "$input_path/*.bam" \
-  -ref $refdata_path \
-  -p $PWD/project_folder
-```
-
-### Using Docker
-```
-docker pull kccg/clinsv
-project_folder=$PWD/test_run
-docker run \
--v $refdata_path:/app/ref-data \
--v $project_folder:/app/project_folder \
--v $input_path:/app/input \
-  kccg/clinsv -r all \
--i "/app/input/*.bam" \
--ref $refdata_path:/app/ref-data \
--p $project_folder:/app/project_folder
-```
-
-### Linux Native
-
-Download precompiled ClinSV bundle for CentOS 6.8 x86_64
-
-```
-wget https://clinsv.s3.ccia.org.au/clinsv_b37/ClinSV_x86_64_v0.9.tar.gz
-tar zxf ClinSV_x86_64_v0.9.tar.gz
-clinsv_path=$PWD/clinsv
-export PATH=$clinsv_path/bin:$PATH
-clinsv -r all -p $PWD/project_folder -i "$input_path/*.bam" -ref $refdata_path
-```
 
 ### Compile dependencies from source
 see [INSTALL.md](INSTALL.md)
@@ -237,20 +228,20 @@ If ClinSV was executed on a remote computer, like an HPC, then the file paths mi
 
 You have several options to improve this:
 
-1: The `-p` parameter accepts two arguments, the first is the desired path on your desktop/localhost, the second is the path on the execution host where the job needs to run. For example `-p /path/on/desktop:/app/project_folder/`. In this case the session.xml will have
+1. The `-p` parameter accepts two arguments, the first is the desired path on your desktop/localhost, the second is the path on the execution host where the job needs to run. For example `-p /path/on/desktop:/app/project_folder/`. In this case the session.xml will have
 ```
 <Resource path="/path/on/desktop/test_run/igv/alignments/Sample/bw/Sample.q0.bw"/>
 ```
 Once you copy the results to `/path/on/desktop`, the session file will now work.
 
-2: paths can be relative to the igv xml file, so `-p ..:/app/project_folder/` will create:
+2. paths can be relative to the igv xml file, so `-p ..:/app/project_folder/` will create:
 ```
 <Resource path="../alignments/Sample/bw/Sample.q0.bw"/>
 ```
 
-3: manually replace the paths in the XML file with a perl regex, eg `perl -pi -e 's|/app/project_folder/|/path/on/desktop/|g' $xml`
+3. manually replace the paths in the XML file with a perl regex, eg `perl -pi -e 's|/app/project_folder/|/path/on/desktop/|g' $xml`
 
-4: mount the remote folder on your desktop (eg sshfs) using the same folder structure
+4. mount the remote folder on your desktop (eg sshfs) using the same folder structure
 
 Consider specifying the `-w` option to allow the annotation tracks to be streamed in from our server. This is convenient if you don't want to have the full annotation bundle on your desktop.
 
@@ -258,12 +249,73 @@ When the IGV application is open, the hyperlinks within the `sample.RARE_PASS_GE
 
 For more information please see the publication.
 
+## Dev tips
+ClinSV works by creating shell scripts which aggregate multiple tools together. How these scripts are defined is specified in [main clinsv perl script](clinsv). These are then run for each job. There are 6 jobs run by clinsv `bigwig,lumpy,cnvnator,annotate,prioritize,qc`. These are defined as functions with the same name in the [main clinsv perl script](clinsv). They all contain sub-jobs:
+
+```
+    "bigwig":{
+            "createWigs": "walltime=6:00:00,ncpus=16,mem=10GB",
+            "q0": "walltime=2:00:00,ncpus=1,mem=60GB,jobfs=100gb",
+            "q20": "walltime=2:00:00,ncpus=1,mem=60GB,jobfs=100gb",
+            "mq" : "walltime=5:00:00,ncpus=1,mem=60GB,jobfs=100gb"
+    },
+    "lumpy":{
+            "caller": "walltime=22:00:00,mem=60GB,ncpus=1,jobfs=300gb",
+            "depth": "walltime=8:00:00,ncpus=12,mem=30GB,jobfs=50G"
+    },
+    "cnvnator":{
+            "caller": "walltime=6:00:00,mem=30GB,ncpus=16,jobfs=300gb"
+    },
+    "annotate":{
+            "main":"walltime=10:00:00,mem=10GB,ncpus=1,jobfs=20gb"
+    },
+    "prioritize":{
+            "main": "walltime=1:00:00,mem=3GB,ncpus=1,jobfs=20gb"
+    },
+    "qc":{
+            "main": "walltime=01:00:00,mem=2GB,ncpus=1,jobfs=20gb"
+    }
+
+```
+### Container Development
+Installing the dependencies for ClinSV can be quite hard. It is recommended that development in done in the provided docker container. There is two ways to approach this:
+#### Method 1: Developing outside the container then attaching dev volumes.
+1. Set up your dev working directory as the same file structure used to run the docker image.
+2. Download all required reference genomes and sample BAM files (use subsampled bam for quicker performance testing) and place them in the respective folders described in step 1.
+3. Set the environment variables used to mount the volumes to the docker container. As described in the run docker container instructions.
+4. Git clone/pull clinsv into the current working directory
+5. Set a ClinSV repo path environment variable to the cloned/pulled ClinSV git repo: `clinsv_repo_path=$PWD/ClinSV/`
+6. Run the docker of latest version of ClinSV in interactive mode mounting the `clinsv_repo_path variable` to the app folder in the docker container: `docker run -v $refdata_path:/app/ref-data
+-v $project_folder:/app/project_folder 
+-v $input_path:/app/input 
+-v $clinsv_repo_path:/app/clinsv_repo
+-it containerregistrypubliccb.azurecr.io/clinsv:v1.1.0`
+7. Write dev changes to the ClinSV repo and save.
+8. In the running docker container run: `sh /app/clinsv_repo/Utils/insert_git_repo_into_docker.sh`. This will apply all the changes made in the ClinSV repo outside the container to the appropriate areas in the ClinSV docker container.
+9. Run ClinSV inside the container to test changes.
+
+#### Method 2: Developing inside the container directly.
+1. Using Visual Studio Code, download the [Visual Studio Code Dev Containers extension](https://code.visualstudio.com/docs/devcontainers/containers).
+2. Set up your dev working directory as the same file structure used to run the docker image.
+3. Download all required reference genomes and sample BAM files (use subsampled bam for quicker performance testing) and place them in the respective folders described in step 1.
+4. Set the environment variables used to mount the volumes to the docker container. As described in the run docker container instructions.
+`docker run -v $refdata_path:/app/ref-data
+-v $project_folder:/app/project_folder 
+-v $input_path:/app/input 
+-it containerregistrypubliccb.azurecr.io/clinsv:v1.1.0`
+5. Using the Visual Studio Code Dev Containers extension attach VS code to the running container. 
+6. In the running container create the folder `/app/clinsv_repo/`.
+7. Git clone ClinSV into `/app/clinsv_repo/`.
+8. Write dev changes to the ClinSV repo and save. This is done nicely using VS code.
+9. In the running docker container run: `sh /app/clinsv_repo/Utils/insert_git_repo_into_docker.sh`. This will apply all the changes made in the `/app/clinsv_repo/` to the appropriate areas in the ClinSV docker container.
+10. Run ClinSV inside the container to test changes.
+ 
 ## Commonly asked questions
 1. Does ClinSV support long read data (Nanopore or PacBio)? No.
 2. Does ClinSV work on targeted short read NGS data (eg WES or panels)? No, it only works on WGS.
 3. Does ClinSV work on NovaSeq data? Yes it should be fine, but the control data was generated on HiSeq X & much of the strength of ClinSV is removing the noise that can happen when searching genome-wide.
 4. Why does my BAM not work? You must have one sample name 'SM' defined in the BAM header.
-5. Can i run hundreds of BAM files through ClinSV? We mostly tested ClinSV on trios or small numbers of WGS, so this probably won't work.
+5. Can I run hundreds of BAM files through ClinSV? We mostly tested ClinSV on trios or small numbers of WGS, so this probably won't work.
 6. Will you support CRAM? Yes, one day.
 7. Can I use hg19? Yes you can use the -hg19 flag while using the hs37d5 or b37 ref genome. The hs37d5 ref genome (and the b37), have chrom names are 1, 2, ..., X, Y, MT. Whilst grch38, have chrom names are chr1,chr2,...,chrX,chrY.
 8. Do you support alt/no alts? ClinSV should accept any of the versions of GRCh38, but will only analyse CNV or SV on the autosomes, and allosomes (X and Y).

--- a/Utils/README.md
+++ b/Utils/README.md
@@ -1,0 +1,13 @@
+# Utils
+This folder contains scripts or example utility files.
+
+## insert_git_repo_into_docker.sh
+Puts the ClinSV repo files mounted to /app/clinsv to replace all scripts being used to run ClinSV in the docker container.
+
+## resource_available.json 
+Example json file to be used with the `-j` command. Modify the respective `walltime=hh:mm:ss,ncpus=X,mem=YGB,jobfs=ZGB` to restrict resources used per step. By default, ClinSV will use the same resource restrictions as resource_available.json 
+
+- `walltime=hh:mm:ss`: This sets the maximum amount of real time the job may use. It’s called “wall time” because it’s the actual time as would be measured by a clock on the wall. The format is hours:minutes:seconds. If your job exceeds this time, it will be terminated.
+- `ncpus=X`: This sets the number of CPU cores that the job can use. Replace ‘X’ with the number of cores you want to allocate to your job.
+- `mem=YGB`: This sets the maximum amount of RAM memory that the job can use. Replace ‘Y’ with the amount of memory you want to allocate to your job. The ‘GB’ indicates that the value is in gigabytes.
+- `jobfs=ZGB`: This sets the amount of disk space that the job can use for temporary storage. Replace ‘Z’ with the amount of disk space you want to allocate to your job. The ‘GB’ indicates that the value is in gigabytes.

--- a/Utils/resource_available.json
+++ b/Utils/resource_available.json
@@ -1,25 +1,25 @@
 {
     "bigwig":{
             "createWigs": "walltime=6:00:00,ncpus=16,mem=10GB",
-            "q0": "walltime=2:00:00,ncpus=1,mem=60GB,jobfs=100gb",
-            "q20": "walltime=2:00:00,ncpus=1,mem=60GB,jobfs=100gb",
-            "mq" : "walltime=5:00:00,ncpus=1,mem=60GB,jobfs=100gb"
+            "q0": "walltime=2:00:00,ncpus=1,mem=60GB,jobfs=100GB",
+            "q20": "walltime=2:00:00,ncpus=1,mem=60GB,jobfs=100GB",
+            "mq" : "walltime=5:00:00,ncpus=1,mem=60GB,jobfs=100GB"
     },
     "lumpy":{
-            "caller": "walltime=22:00:00,mem=60GB,ncpus=1,jobfs=300gb",
-            "depth": "walltime=8:00:00,ncpus=12,mem=30GB,jobfs=50G"
+            "caller": "walltime=22:00:00,ncpus=1,mem=60GB,jobfs=300GB",
+            "depth": "walltime=8:00:00,ncpus=12,mem=30GB,jobfs=50GB"
     },
     "cnvnator":{
-            "caller": "walltime=6:00:00,mem=30GB,ncpus=16,jobfs=300gb"
+            "caller": "walltime=6:00:00,mem=30GB,ncpus=16,jobfs=300GB"
     },
     "annotate":{
-            "main":"walltime=10:00:00,mem=10GB,ncpus=1,jobfs=20gb"
+            "main":"walltime=10:00:00,mem=10GB,ncpus=1,jobfs=20GB"
     },
     "prioritize":{
-            "main": "walltime=1:00:00,mem=3GB,ncpus=1,jobfs=20gb"
+            "main": "walltime=1:00:00,mem=3GB,ncpus=1,jobfs=20GB"
     },
     "qc":{
-            "main": "walltime=01:00:00,mem=2GB,ncpus=1,jobfs=20gb"
+            "main": "walltime=01:00:00,mem=2GB,ncpus=1,jobfs=20GB"
     }
 
 

--- a/clinsv
+++ b/clinsv
@@ -1585,8 +1585,8 @@ usage: clinsv -p /path/to/project -i /path/to/input_bams/*.bam -ref /path/to/ref
 -l Lumpy batch size. Number of sampels to be joint-called [15]. 
 -ref Path to reference data dir [./refdata-b38 or ./refdata-b37]. This can take two colon separated values, see README.md
 -hg19 Specify that input bams use hg19 chromosome nomenclature (e.g. short form '1,2,3..X,Y,MT'), use when using input bams that are
-aligned to hg19. Ensure sure with the reference data dir refdata-b37. Warning this is an unstable feature. Highly recommend to lift over input bams to
-GRCH37/GRCH8 with another tool like CrossMap, then use ClinSV with those ref genomes as usual.
+      aligned to hg19. Ensure to use with the reference data refdata-b37. Warning this is an unstable feature. Highly recommend to lift over input bams to
+      GRCh37/GRCh38 with another tool, then use ClinSV with those ref genomes.
 
 -eval Create the NA12878 validation report section [no].
 -h print this help

--- a/clinsv
+++ b/clinsv
@@ -487,11 +487,7 @@ sub lumpy {
 			
 			foreach $cReadGroupID (keys %{$fastq{$cSample}}){
 				$outStemSC=$cReadGroupID; $outStemSC=~ s/\-/_/g;		
-				print OUT "readLArr[$outStemSC]=\$(samtools view  $projectDir/alignments/$cSample/$cSample.bam ".$chrPf."1:1000000-1100000 | cut -f 10 | awk '{ print length}' | sort -rn | awk '(NR==1){print}' )\n";
-				
-				# Test to make sure readLArr[$outStemSC] is not empty as we the bam could be aligned to a different naming convention. If so try the hg19 naming convention
-				# print OUT "[ -z \"$readLArr[$outStemSC]\" ] && readLArr[$outStemSC]=\$(samtools view  $projectDir/alignments/$cSample/$cSample.bam chr1:1000000-1100000 | cut -f 10 | awk '{ print length}' | sort -rn | awk '(NR==1){print}' )\n";
-				
+				print OUT "readLArr[$outStemSC]=\$(samtools view  $projectDir/alignments/$cSample/$cSample.bam ".$chrPf."1:1000000-1100000 | cut -f 10 | awk '{ print length}' | sort -rn | awk '(NR==1){print}' )\n";				
 				print OUT "read -r mean stdev <<< \$( samtools view -r $cReadGroupID $projectDir/alignments/$cSample/$cSample.bam | python3 $S_SV_scriptDir/pairend_distro-a1.py -r \${readLArr[$outStemSC]} -X 2 -N 100000 -o $r_PreProc/$cReadGroupID.pe.histo | cut -d \":\" -f 2 )\n";		
 				print OUT "meanArr[$outStemSC]=\$mean;stdevArr[$outStemSC]=\$stdev;\n";
 			}	

--- a/clinsv
+++ b/clinsv
@@ -345,11 +345,25 @@ sub bigwig {
 		print OUT "cd $r_OutDir/\n";
 
 		#Get max number of CPUs allocated
-		$max_ncpu  = $job_resource =~ /ncpus=(\d+)/;
+		if ($job_resource =~ /ncpus=(\d+)/)
+		{
+			$max_ncpu = $1;
+		}else{
+			print STDERR "Unable to extract out max ncpu from $job_resource. Please ensure this is in the form of walltime=hh:mm:ss,ncpus=X,mem=YGB in the -j resource availble json\n";
+			exit (1);
+		}
+		
+		#
+		if ($max_ncpu <= 1){
 
-		#If the num of cpus available is greater than the allocated cpus, use the max allocated. Otherwise use the max cpus available from 'nproc' command. Accounting for 1 cpu used small contigs.
-		print OUT "(( ncpus = `nproc` <  $max_ncpu - 1 ? `nproc` : $max_ncpu - 1 ))\n";
+			print OUT "(( ncpus = `nproc` < 1 ?  `nproc` :1))\n";
+		}else{
 
+			#If the num of cpus available is greater than the allocated cpus, use the max allocated. Otherwise use the max cpus available from 'nproc' command. Accounting for 1 cpu used small contigs.
+			print OUT "(( ncpus = `nproc` <  $max_ncpu - 1 ? `nproc` : $max_ncpu - 1 ))\n";
+
+		}
+		
 		foreach $cT (("q0","q20","mq")){ # create bw of s1 for MQ>=0 and MQ>=20
 
 			if($cT eq "mq"){
@@ -542,10 +556,16 @@ sub lumpy {
 		$$cJ{rJobResource}=$job_resource;
 
 		#Get max number of CPUs allocated
-		$max_ncpu  = $job_resource =~ /ncpus=(\d+)/;
-
-		#If the num of cpus available is greater than the allocated cpus, use the max allocated. Otherwise use the max cpus available from 'nproc' command.
-		print OUT "(( ncpus = `nproc` <  $max_ncpu ? `nproc` : $max_ncpu))\n";
+		if ($job_resource =~ /ncpus=(\d+)/)
+		{
+			$max_ncpu = $1;
+		}else{
+			print STDERR "Unable to extract out max ncpu from $job_resource. Please ensure this is in the form of walltime=hh:mm:ss,ncpus=X,mem=YGB in the -j resource availble json\n";
+			exit (1);
+		}
+		
+		#If the num of cpus available is greater than the allocated cpus, use the max allocated. Otherwise use the max cpus available from 'nproc' command. Accounting for 1 cpu used small contigs.
+		print OUT "(( ncpus = `nproc` <  $max_ncpu ? `nproc` : $max_ncpu ))\n";
 
 # 		$$cJ{rQueueType}="express";
 		open(OUT,">$$cJ{rShStem}.sh");
@@ -1494,13 +1514,13 @@ sub check_resource_available_keys {
     foreach my $key (keys %expected_keys) {
         unless (exists $resource_available->{$key}) {
             print {STDERR} "\n **** error: Key '$key' does not exist in the resourse_available.json.\n";
-            exit;
+            exit (1);
         }
 
         foreach my $subkey (@{$expected_keys{$key}}) {
             unless (exists $resource_available->{$key}->{$subkey}) {
                 print  {STDERR} "\n **** error: Subkey '$subkey' does not exist under key '$key' in the resourse_available.json.\n";
-                exit;
+                exit (1);
             }
         }
     }

--- a/clinsv
+++ b/clinsv
@@ -1581,7 +1581,7 @@ usage: clinsv -p /path/to/project -i /path/to/input_bams/*.bam -ref /path/to/ref
    project folder, E.g. a family trio and a set of single proband individuals.
 -w short for 'web': In the IGV session file, stream the annotation tracks from a server. Convenient if you
     prefer to run ClinSV on an HPC (where you have a copy of the annotation bundle) and view results on your desktop 
--j Path to json file which specifies the resources to be used for each step [./clinsv/resource_available.json]
+-j Path to json file which specifies the resources to be used for each step
 -l Lumpy batch size. Number of sampels to be joint-called [15]. 
 -ref Path to reference data dir [./refdata-b38 or ./refdata-b37]. This can take two colon separated values, see README.md
 -hg19 Specify that input bams use hg19 chromosome nomenclature (e.g. short form '1,2,3..X,Y,MT'), use when using input bams that are

--- a/clinsv
+++ b/clinsv
@@ -63,7 +63,13 @@ $resource_available = read_json($resource_available_path);
 # Checks that the resource_availble json contains keys for all required steps
 check_resource_available_keys($resource_available);
 
+# If no project dir is given default to cwd
+if (length($projectDir)<1){
+	$projectDir=cwd();
+}else{
+	$projectDir = abs_path $projectDir;
 
+}
 ## check projectDir
 @bamInArr=glob("$inputAlignDir");
 if(scalar(@bamInArr)==0){print {STDERR} "\n **** error: no bam files found under $inputAlignDir **** \n"; printHelp(); exit}
@@ -396,7 +402,7 @@ sub lumpy {
 	
 	$r_head="set -e -x -o pipefail\n\n"; 
 	$r_head.=$S_python."export PATH=$softBin:\$PATH\n"; 
-	print  "# $r_JobType\n\n";
+	print  "\n# $r_JobType\n\n";
 	
 	################ preprocessing
 	foreach $cSample (sort keys %fastq){
@@ -559,7 +565,7 @@ sub lumpy {
 sub cnvnator {
   
   	$r_JobType="cnvnator";
-	print  "# cnvnator\n\n";	
+	print  "\n# $r_JobType\n\n";	
 
 	### write cnvnator commands sampleInfoFile
 	$r_head="";
@@ -602,10 +608,10 @@ sub cnvnator {
 }
 
 sub annotate {
-    
-  	print  "# annotate\n\n";
 	
 	$r_JobType="annotate";
+
+	print  "\n# $r_JobType\n\n";
 	$r_JobSubType="main"; #! edit here
 	
 	
@@ -717,9 +723,9 @@ sub annotate {
 }
 
 sub prioritize {
-	print  "# prioritize\n\n";
-	
+
 	$r_JobType="prioritize";
+	print  "\n# $r_JobType\n\n";
 	$r_JobSubType="main"; #! edit here
 	
 	
@@ -786,10 +792,9 @@ sub prioritize {
 }
 
 sub qc {
-
-	print  "# qc\n\n";
 	
 	$r_JobType="qc";
+	print  "\n# $r_JobType\n\n";
 	$r_JobSubType="main"; #! edit here
 	
 	@SampleOrder=sort keys %fastq;		
@@ -1515,8 +1520,10 @@ usage: clinsv -p /path/to/project -i /path/to/input_bams/*.bam -ref /path/to/ref
 -j Path to json file which specifies the resources to be used for each step [./clinsv/resource_available.json]
 -l Lumpy batch size. Number of sampels to be joint-called [15]. 
 -ref Path to reference data dir [./refdata-b38 or ./refdata-b37]. This can take two colon separated values, see README.md
--hg19 Specify that input bams use hg19 chromosome nomenclature, use when using input bams that are
-	aligned to hg19 along with the reference data dir refdata-b37.
+-hg19 Specify that input bams use hg19 chromosome nomenclature (e.g. short form '1,2,3..X,Y,MT'), use when using input bams that are
+aligned to hg19. Ensure sure with the reference data dir refdata-b37. Warning this is an unstable feature. Highly recommend to lift over input bams to
+GRCH37/GRCH8 with another tool like CrossMap, then use ClinSV with those ref genomes as usual.
+
 -eval Create the NA12878 validation report section [no].
 -h print this help
 

--- a/clinsv
+++ b/clinsv
@@ -564,13 +564,13 @@ sub lumpy {
 			exit (1);
 		}
 		
-		#If the num of cpus available is greater than the allocated cpus, use the max allocated. Otherwise use the max cpus available from 'nproc' command. Accounting for 1 cpu used small contigs.
-		print OUT "(( ncpus = `nproc` <  $max_ncpu ? `nproc` : $max_ncpu ))\n";
-
 # 		$$cJ{rQueueType}="express";
 		open(OUT,">$$cJ{rShStem}.sh");
 		$r_head.="export PERL5LIB=$S_clinsv_dir/perlib:\$PERL5LIB\n";
 		print OUT "$r_head\n";
+
+		#If the num of cpus available is greater than the allocated cpus, use the max allocated. Otherwise use the max cpus available from 'nproc' command. Accounting for 1 cpu used small contigs.
+		print OUT "(( ncpus = `nproc` <  $max_ncpu ? `nproc` : $max_ncpu ))\n";
 		
 		# parallel version with local copy of bw files
 		print OUT "perl -e 'while(<>){ if(/^#/){\$h.=\$_; next;} \@_=split(\"\\t\",\$_); \$c=\$_[0]; if(!exists(\$f{\$c})){ open(\$f{\$c},\">$r_TmpDir/in.\$c.vcf\"); print {\$f{\$c}} \$h; } \n";  

--- a/clinsv
+++ b/clinsv
@@ -339,21 +339,29 @@ sub bigwig {
 		$job_resource = $resource_available->{$r_JobType}->{$r_JobSubType};
 		print "Using resource:".$job_resource." for job ".$r_JobType.":".$r_JobSubType."\n";
 		$$cJ{rJobResource}=$job_resource;
-		
+
 		open(OUT,">$$cJ{rShStem}.sh");	
 		print OUT "$r_head\n\n";	
 		print OUT "cd $r_OutDir/\n";
-		
+
+		#Get max number of CPUs allocated
+		$max_ncpu  = $job_resource =~ /ncpus=(\d+)/;
+
+		#If the num of cpus available is greater than the allocated cpus, use the max allocated. Otherwise use the max cpus available from 'nproc' command. Accounting for 1 cpu used small contigs.
+		print OUT "(( ncpus = `nproc` <  $max_ncpu - 1 ? `nproc` : $max_ncpu - 1 ))\n";
+
 		foreach $cT (("q0","q20","mq")){ # create bw of s1 for MQ>=0 and MQ>=20
+
 			if($cT eq "mq"){
-				print OUT "\n\nawk '\$2>=100000 {print \$1\":1-\"\$2}' $refFasta.chrom.sizes | xargs -P 15 -t -i{} perl $S_SV_scriptDir/bam2wigMQ.pl ";
+
+				print OUT "\n\nawk '\$2>=100000 {print \$1\":1-\"\$2}' $refFasta.chrom.sizes | xargs -P \${ncpus} -t -i{} perl $S_SV_scriptDir/bam2wigMQ.pl ";
 				print OUT "-s 1 -r \"{}\" -o $r_TmpDir/$cSample.$cT -f $refFasta -b $rAlnDir/$cSample.bam\n";
 				
 				print OUT "\n\nawk '\$2<100000 {print \$1\":1-\"\$2}' $refFasta.chrom.sizes | xargs -P 1 -t -i{} perl $S_SV_scriptDir/bam2wigMQ.pl ";
 				print OUT "-s 1 -r \"{}\" -o $r_TmpDir/$cSample.$cT.small_contigs -f $refFasta -b $rAlnDir/$cSample.bam -a \n";
 
 			}else{
-				print OUT "\n\nawk '\$2>=100000 {print \$1\":1-\"\$2}' $refFasta.chrom.sizes | xargs -P 15 -t -i{} perl $S_SV_scriptDir/bam2wig.pl ";
+				print OUT "\n\nawk '\$2>=100000 {print \$1\":1-\"\$2}' $refFasta.chrom.sizes | xargs -P \${ncpus} -t -i{} perl $S_SV_scriptDir/bam2wig.pl ";
 				print OUT "-s 1 -q $cT -r \"{}\" -o $r_TmpDir/$cSample.$cT -f $refFasta -b $rAlnDir/$cSample.bam\n";
 				
 				print OUT "\n\nawk '\$2<100000 {print \$1\":1-\"\$2}' $refFasta.chrom.sizes | xargs -P 1 -t -i{} perl $S_SV_scriptDir/bam2wig.pl ";
@@ -533,6 +541,12 @@ sub lumpy {
 		print "Using resource:".$job_resource." for job ".$r_JobType.":".$r_JobSubType."\n";
 		$$cJ{rJobResource}=$job_resource;
 
+		#Get max number of CPUs allocated
+		$max_ncpu  = $job_resource =~ /ncpus=(\d+)/;
+
+		#If the num of cpus available is greater than the allocated cpus, use the max allocated. Otherwise use the max cpus available from 'nproc' command.
+		print OUT "(( ncpus = `nproc` <  $max_ncpu ? `nproc` : $max_ncpu))\n";
+
 # 		$$cJ{rQueueType}="express";
 		open(OUT,">$$cJ{rShStem}.sh");
 		$r_head.="export PERL5LIB=$S_clinsv_dir/perlib:\$PERL5LIB\n";
@@ -542,7 +556,7 @@ sub lumpy {
 		print OUT "perl -e 'while(<>){ if(/^#/){\$h.=\$_; next;} \@_=split(\"\\t\",\$_); \$c=\$_[0]; if(!exists(\$f{\$c})){ open(\$f{\$c},\">$r_TmpDir/in.\$c.vcf\"); print {\$f{\$c}} \$h; } \n";  
 		print OUT "print {\$f{\$c}} \$_; } foreach (values %f){close} ' $r_OutDir/$nameStemJoint.MQ$LP_MQ.$lumpOrSpeedPreProc$fileExt.vcf \n";			
 
-		print OUT "ls $r_TmpDir/in.*.vcf | xargs -P 12 -t -i{} perl $S_SV_scriptDir/add-depth-to-PE-SR-calls.pl {} $refFasta ".$refChrPf." $projectDir $S_SV_controlSRPE $S_SV_control_number_samples $S_control_bw_folder \n";
+		print OUT "ls $r_TmpDir/in.*.vcf | xargs -P \${ncpus} -t -i{} perl $S_SV_scriptDir/add-depth-to-PE-SR-calls.pl {} $refFasta ".$refChrPf." $projectDir $S_SV_controlSRPE $S_SV_control_number_samples $S_control_bw_folder \n";
 		print OUT "(grep \"#\" $r_TmpDir/in.".$chrPf."1.out; cat $r_TmpDir/in.*.out | grep -v \"#\" | sort -V -k1,1 -k2,2n ) > $r_OutDir/$nameStemJoint.MQ$LP_MQ.$lumpOrSpeedPreProc$fileExt.f1.vcf\n";	
 		
 

--- a/clinsv
+++ b/clinsv
@@ -20,7 +20,7 @@ use Data::Dumper::Simple;
 ######################################## default settings
 ########################################
 
-$clinSvVersion="1.1 (2024-03-08)";
+$clinSvVersion="1.1.0 (2024-03-08)";
 
 $runString="all";
 $inputAlignDir="./input/*.bam";

--- a/clinsv
+++ b/clinsv
@@ -34,8 +34,8 @@ $S_ref_data="$S_clinsv_dir/refdata-b37";
 $projectDir_host='';
 $S_ref_data_host='';
 
-$resource_available_path="$S_clinsv_dir/resource_available.json";
-
+# $resource_available_path="$S_clinsv_dir/resource_available.json";
+$resource_available_path="";
 GetOptions (
 		    "p=s"  => \$projectDir,
 		    "r=s"  => \$runString,
@@ -57,11 +57,16 @@ GetOptions (
 if($help){  printHelp(); exit; }
 if($version){  print "$clinSvVersion\n"; exit; }
 
+if (length($resource_available_path) < 1){
+	# Use default resources
+	$resource_available = use_default_resources();
+}else{
+	# read in json of resources available 
+	$resource_available = read_json($resource_available_path);
+	# Checks that the resource_availble json contains keys for all required steps
+	check_resource_available_keys($resource_available);
+}
 
-$resource_available = read_json($resource_available_path);
-
-# Checks that the resource_availble json contains keys for all required steps
-check_resource_available_keys($resource_available);
 
 # If no project dir is given default to cwd
 if (length($projectDir)<1){
@@ -1487,6 +1492,35 @@ sub check_resource_available_keys {
     }
 
     print "All expected keys and subkeys exist in the resourse_available.json.\n";
+}
+
+# Creates the resource_available hash to use default values
+sub use_default_resources {
+
+	my $resource_available = {};
+
+	# bigwig
+	$resource_available->{'bigwig'}->{'createWigs'} =  "walltime=6:00:00,ncpus=16,mem=10GB";
+	$resource_available->{'bigwig'}->{'q0'} = "walltime=2:00:00,ncpus=1,mem=60GB,jobfs=100gb";
+	$resource_available->{'bigwig'}->{'q20'} = "walltime=2:00:00,ncpus=1,mem=60GB,jobfs=100gb";
+	$resource_available->{'bigwig'}->{'mq'} = "walltime=5:00:00,ncpus=1,mem=60GB,jobfs=100gb";
+
+	# lumpy
+	$resource_available->{'lumpy'}->{'caller'} = "walltime=22:00:00,mem=60GB,ncpus=1,jobfs=300gb";
+	$resource_available->{'lumpy'}->{'depth'} = "walltime=8:00:00,ncpus=12,mem=30GB,jobfs=50G";
+
+	# cnvnator
+	$resource_available->{'cnvnator'}->{'caller'} = "walltime=6:00:00,mem=30GB,ncpus=16,jobfs=300gb";
+
+	# annotate
+	$resource_available->{'annotate'}->{'main'} = "walltime=10:00:00,mem=10GB,ncpus=1,jobfs=20gb";
+
+	# prioritize
+	$resource_available->{'prioritize'}->{'main'} = "walltime=1:00:00,mem=3GB,ncpus=1,jobfs=20gb";
+
+	# qc
+	$resource_available->{'qc'}->{'main'} = "walltime=01:00:00,mem=2GB,ncpus=1,jobfs=20gb";
+	return $resource_available;
 }
 sub printHelp{
 


### PR DESCRIPTION
- Able to use either ref-genomes on the fly depending on the file path passed into the `-ref` command. `-ref /app/ref-data/refdata-b38` for GRCh38 (b38) and `-ref /app/ref-data/refdata-b37` for GRCh38 (b37).
- Support of hg19 style nomenclature (ex `1,2,3,4..X,Y,MT`) for input bams using the b37 reference genome. Note this is an unstable feature. It is recommended to lift over your bam files first to the ref genome you would want to use.
-  Able to use maximum available CPUs for the bigwig:createWigs and lumpy:caller steps.
- Able to limit the amount of CPUs used by ClinSV with the `-j` command where a path to a json file which contains the max limit on resources used for each step is passed as input. For more details see Utils/ Readme
- Added script to make a smoother development experience using the docker container. For more details see Utils/ Readme.
- Bug fix #61: igv .xml file now uses the correct reference genome dependeant on the reference genome used.
- Bug fix #60: the coverage by chromosome view in the QC report is now outputed correctly.

